### PR TITLE
Add `--paths` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ Examples:
 
   # Output to a file
   git-to-prompt log -o log.xml
+
+  # Filter commits by path
+  git-to-prompt log --path path/to/file.py
+
+  # Filter commits by multiple paths
+  git-to-prompt log --path path/to/file.py another/path
+
+  # Combine with revision range
+  git-to-prompt log HEAD~10..HEAD --path path/to/file.py
 ```
 
 ## Output Format

--- a/README.md
+++ b/README.md
@@ -35,16 +35,20 @@ This outputs Git commits in a Claude XML format that's well-suited for LLM promp
 ### Options
 
 ```
-Usage: git-to-prompt log [OPTIONS] [REVISION_RANGE]
+Usage: git-to-prompt log [REVISION_RANGE] [PATHS] [OPTIONS]
 
   Generate a formatted log of git commits suitable for LLM prompts.
 
   Outputs in Claude XML format, which is designed to be easily parseable by large
   language models while maintaining the structured nature of git commit data.
 
+Arguments:
+  REVISION_RANGE  Revision range (e.g., 'HEAD~5..HEAD') or -- to separate paths
+  PATHS           Paths to filter commits by (only commits affecting these paths will be shown)
+
 Options:
   -n, --max-count INTEGER       Maximum number of commits to show
-  --include-patch / --no-patch  Include commit diffs in the output (default: include)
+  -p, -u, --patch / --no-patch  Include commit diffs in the output (default: false)
   -o, --output PATH             Output file (defaults to stdout)
   --repo-path DIRECTORY         Path to the Git repository (defaults to current directory)
   --help                        Show this message and exit.
@@ -59,14 +63,14 @@ Examples:
   # Output to a file
   git-to-prompt log -o log.xml
 
-  # Filter commits by path
-  git-to-prompt log --path path/to/file.py
+  # Filter commits by path (using -- syntax, just like git)
+  git-to-prompt log -- path/to/file.py
 
   # Filter commits by multiple paths
-  git-to-prompt log --path path/to/file.py another/path
+  git-to-prompt log -- path/to/file.py another/path
 
-  # Combine with revision range
-  git-to-prompt log HEAD~10..HEAD --path path/to/file.py
+  # Combine with revision range and paths
+  git-to-prompt log HEAD~10..HEAD path/to/file.py
 ```
 
 ## Output Format

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This outputs Git commits in a Claude XML format that's well-suited for LLM promp
 ### Options
 
 ```
-Usage: git-to-prompt log [REVISION_RANGE] [PATHS] [OPTIONS]
+Usage: git-to-prompt log [<options>] [<revision-range>] [[--] <path>...]
 
   Generate a formatted log of git commits suitable for LLM prompts.
 
@@ -43,8 +43,8 @@ Usage: git-to-prompt log [REVISION_RANGE] [PATHS] [OPTIONS]
   language models while maintaining the structured nature of git commit data.
 
 Arguments:
-  REVISION_RANGE  Revision range (e.g., 'HEAD~5..HEAD') or -- to separate paths
-  PATHS           Paths to filter commits by (only commits affecting these paths will be shown)
+  <revision-range>   Revision range (e.g., 'HEAD~5..HEAD')
+  <path>...          Paths to filter commits by (only commits affecting these paths will be shown)
 
 Options:
   -n, --max-count INTEGER       Maximum number of commits to show

--- a/src/git_to_prompt/cli.py
+++ b/src/git_to_prompt/cli.py
@@ -25,19 +25,16 @@ def revision_range_validator(type_, value: str):
 @app.command
 def log(
     revision_range: Annotated[
-        str | None, 
+        str | None,
         Parameter(
             help="Revision range (e.g., 'HEAD~5..HEAD')",
-            validator=revision_range_validator, 
-            allow_leading_hyphen=True
-        )
+            validator=revision_range_validator,
+            allow_leading_hyphen=True,
+        ),
     ] = None,
     paths: Annotated[
-        list[Path], 
-        Parameter(
-            help="Paths to filter commits by",
-            allow_leading_hyphen=True
-        )
+        list[Path],
+        Parameter(help="Paths to filter commits by", allow_leading_hyphen=True),
     ] = [],
     /,
     include_patch: Annotated[
@@ -112,11 +109,13 @@ def log(
         # When we're in a subdirectory, we need to convert relative paths to be relative to repo root
         repo_root = Path(repo.working_dir)
         current_dir = Path.cwd()
-        
+
         # If we're in a subfolder of the repo, adjust the paths accordingly
         path_strs = []
         if paths:
             for p in paths:
+                if p.name == "--":
+                    continue
                 path_obj = Path(p)
                 # If it's already an absolute path within the repo, use it as is but make relative to repo root
                 if path_obj.is_absolute() and repo_root in path_obj.parents:
@@ -124,7 +123,9 @@ def log(
                 # For relative paths, we need to adjust based on our current location
                 else:
                     # Determine if we're in a subfolder of the repo
-                    if current_dir != repo_root and current_dir.is_relative_to(repo_root):
+                    if current_dir != repo_root and current_dir.is_relative_to(
+                        repo_root
+                    ):
                         # If we're in a subfolder and path is relative, we need to make it relative to the repo root
                         # First calculate the path relative to current dir (which may be a subfolder)
                         # Then calculate the current dir relative to repo root

--- a/src/git_to_prompt/cli.py
+++ b/src/git_to_prompt/cli.py
@@ -46,6 +46,14 @@ def log(
             validator=validators.Path(exists=True, file_okay=False),
         ),
     ] = Path.cwd(),
+    paths: Annotated[
+        list[str],
+        Parameter(
+            help="Paths to filter commits by (only commits affecting these paths will be shown)",
+            consume_multiple=True,
+            name=["--path", "-p"],
+        ),
+    ] = [],
 ) -> None:
     """
     Generate a formatted log of git commits suitable for LLM prompts.
@@ -63,13 +71,22 @@ def log(
 
         # Output to a file
         git-to-prompt log -o log.xml
+
+        # Filter commits by path (all arguments after -- are treated as paths)
+        git-to-prompt log --path path/to/file.py
+
+        # Filter commits by multiple paths
+        git-to-prompt log --path path/to/file.py another/path
+
+        # Combine with revision range
+        git-to-prompt log HEAD~10..HEAD --path path/to/file.py
     """
     try:
         # Find the Git repository
         repo = get_repo(repo_path)
 
         # Get the commits
-        commits = get_commits(repo, revision_range, include_patch, max_count)
+        commits = get_commits(repo, revision_range, include_patch, max_count, paths)
 
         # Write the commits to the output
         if output:

--- a/src/git_to_prompt/cli.py
+++ b/src/git_to_prompt/cli.py
@@ -27,7 +27,7 @@ def log(
     revision_range: Annotated[
         str | None, 
         Parameter(
-            help="Revision range (e.g., 'HEAD~5..HEAD') or -- to separate paths",
+            help="Revision range (e.g., 'HEAD~5..HEAD')",
             validator=revision_range_validator, 
             allow_leading_hyphen=True
         )
@@ -35,7 +35,7 @@ def log(
     paths: Annotated[
         list[Path], 
         Parameter(
-            help="Paths to filter commits by (only commits affecting these paths will be shown)",
+            help="Paths to filter commits by",
             allow_leading_hyphen=True
         )
     ] = [],
@@ -70,6 +70,8 @@ def log(
 ) -> None:
     """
     Generate a formatted log of git commits suitable for LLM prompts.
+
+    Usage: git-to-prompt log [<options>] [<revision-range>] [[--] <path>...]
 
     Outputs in Claude XML format, which is designed to be
     easily parseable by large language models while maintaining the

--- a/src/git_to_prompt/cli.py
+++ b/src/git_to_prompt/cli.py
@@ -108,7 +108,33 @@ def log(
             revision_range = None
 
         # Convert path objects to strings for GitPython
-        path_strs = [str(p) for p in paths] if paths else []
+        # GitPython path handling works like git - paths should be relative to the repository root
+        # When we're in a subdirectory, we need to convert relative paths to be relative to repo root
+        repo_root = Path(repo.working_dir)
+        current_dir = Path.cwd()
+        
+        # If we're in a subfolder of the repo, adjust the paths accordingly
+        path_strs = []
+        if paths:
+            for p in paths:
+                path_obj = Path(p)
+                # If it's already an absolute path within the repo, use it as is but make relative to repo root
+                if path_obj.is_absolute() and repo_root in path_obj.parents:
+                    path_strs.append(str(path_obj.relative_to(repo_root)))
+                # For relative paths, we need to adjust based on our current location
+                else:
+                    # Determine if we're in a subfolder of the repo
+                    if current_dir != repo_root and current_dir.is_relative_to(repo_root):
+                        # If we're in a subfolder and path is relative, we need to make it relative to the repo root
+                        # First calculate the path relative to current dir (which may be a subfolder)
+                        # Then calculate the current dir relative to repo root
+                        # Finally combine them to get the proper path relative to repo root
+                        subfolder_path = current_dir.relative_to(repo_root)
+                        full_path = subfolder_path / path_obj
+                        path_strs.append(str(full_path))
+                    else:
+                        # We're at repo root or outside the repo, use the path as is
+                        path_strs.append(str(path_obj))
 
         # Get the commits
         commits = get_commits(repo, revision_range, include_patch, max_count, path_strs)

--- a/src/git_to_prompt/log.py
+++ b/src/git_to_prompt/log.py
@@ -151,11 +151,11 @@ def _get_change_type(diff: Diff) -> str:
 
 
 def get_commits(
-    repo: Repo, 
-    revision_range: str | None, 
-    include_diffs: bool, 
-    max_count: int | None, 
-    paths: str | PathLike[str] | Sequence[str | PathLike[str]] | None = None
+    repo: Repo,
+    revision_range: str | None,
+    include_diffs: bool,
+    max_count: int | None,
+    paths: str | PathLike[str] | Sequence[str | PathLike[str]] | None = None,
 ) -> Generator[Commit]:
     """
     Get commits from the repository for the given revision range.
@@ -171,7 +171,7 @@ def get_commits(
         Commit objects for each commit in the range
     """
     # If paths is None, use empty string which means no path filtering
-    path_arg = paths if paths is not None else ''
+    path_arg = paths if paths is not None else ""
     commits = repo.iter_commits(rev=revision_range, paths=path_arg)
 
     for git_commit in itertools.islice(commits, max_count):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,9 @@
-import pytest
-import sys
-from unittest.mock import patch, MagicMock, call
 from pathlib import Path
-import tempfile
-from io import StringIO
+from unittest.mock import MagicMock, patch
 
-from git_to_prompt.cli import log, app
-from git_to_prompt.log import get_commits
+import pytest
+
+from git_to_prompt.cli import app
 
 
 @pytest.fixture
@@ -39,14 +36,14 @@ def mock_write_commits():
 
 
 def test_log_with_paths(mock_get_repo, mock_get_commits, mock_write_commits):
-    """Test log function with paths parameter."""
+    """Test log command with paths parameter."""
     # Setup
     repo_mock = MagicMock()
     mock_get_repo.return_value = repo_mock
-    
-    # Call the function - simulate passing paths positionally
-    log(None, [Path("test/file.py"), Path("another/file.py")], include_patch=False)
-    
+
+    # Call the app with a command string
+    app("log -- test/file.py another/file.py")
+
     # Check if get_commits was called with the correct path parameters
     mock_get_commits.assert_called_once()
     args, _ = mock_get_commits.call_args
@@ -55,15 +52,17 @@ def test_log_with_paths(mock_get_repo, mock_get_commits, mock_write_commits):
     assert args[4] == ["test/file.py", "another/file.py"]  # paths
 
 
-def test_log_with_dash_dash_revision_range(mock_get_repo, mock_get_commits, mock_write_commits):
-    """Test log function with -- as revision range."""
+def test_log_with_dash_dash_revision_range(
+    mock_get_repo, mock_get_commits, mock_write_commits
+):
+    """Test log command with -- as revision range."""
     # Setup
     repo_mock = MagicMock()
     mock_get_repo.return_value = repo_mock
-    
-    # Call the function - simulate passing -- and paths
-    log("--", [Path("test/file.py")], include_patch=False)
-    
+
+    # Call the app with a command string
+    app("log -- test/file.py")
+
     # Check if get_commits was called with revision_range=None (-- is converted to None)
     mock_get_commits.assert_called_once()
     args, _ = mock_get_commits.call_args
@@ -72,15 +71,17 @@ def test_log_with_dash_dash_revision_range(mock_get_repo, mock_get_commits, mock
     assert args[4] == ["test/file.py"]  # paths
 
 
-def test_log_with_regular_revision_range_and_paths(mock_get_repo, mock_get_commits, mock_write_commits):
-    """Test log function with regular revision range and paths."""
+def test_log_with_regular_revision_range_and_paths(
+    mock_get_repo, mock_get_commits, mock_write_commits
+):
+    """Test log command with regular revision range and paths."""
     # Setup
     repo_mock = MagicMock()
     mock_get_repo.return_value = repo_mock
-    
-    # Call the function
-    log("HEAD~5..HEAD", [Path("test/file.py")], include_patch=False)
-    
+
+    # Call the app with a command string
+    app("log HEAD~5..HEAD -- test/file.py")
+
     # Check if get_commits was called with the correct arguments
     mock_get_commits.assert_called_once()
     args, _ = mock_get_commits.call_args
@@ -89,27 +90,30 @@ def test_log_with_regular_revision_range_and_paths(mock_get_repo, mock_get_commi
     assert args[4] == ["test/file.py"]  # paths
 
 
-# The core functionality is tested through direct function tests
-
-
-def test_log_with_relative_paths_from_subfolder(mock_get_repo, mock_get_commits, mock_write_commits):
-    """Test log function with relative paths when executed from a subfolder."""
+def test_log_with_relative_paths_from_subfolder(
+    mock_get_repo, mock_get_commits, mock_write_commits
+):
+    """Test log command with relative paths when executed from a subfolder."""
     # Setup
     repo_mock = MagicMock()
     repo_mock.working_dir = "/repo/root"
     mock_get_repo.return_value = repo_mock
-    
+
     # Mock current working directory to be a subfolder of the repo
     with patch("pathlib.Path.cwd") as mock_cwd:
         mock_cwd.return_value = Path("/repo/root/some/subfolder")
-        
-        # Call the function with a relative path
-        log(None, [Path("../another/file.py"), Path("./current/file.py")], include_patch=False)
-    
+
+        # Call the app with a command string using relative paths
+        app("log -- ../another/file.py ./current/file.py")
+
     # Check if get_commits was called with paths properly adjusted to be relative to repo root
     mock_get_commits.assert_called_once()
     args, _ = mock_get_commits.call_args
     assert args[0] == repo_mock  # repo
     assert args[1] is None  # revision_range
-    assert "some/subfolder/current/file.py" in args[4]  # Relative path from current folder
-    assert "some/subfolder/../another/file.py" in args[4]  # The path is added but .. is not resolved
+    assert (
+        "some/subfolder/current/file.py" in args[4]
+    )  # Relative path from current folder
+    assert (
+        "some/subfolder/../another/file.py" in args[4]
+    )  # The path is added but .. is not resolved

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,86 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+from git_to_prompt.cli import log
+from git_to_prompt.log import get_commits
+
+
+@pytest.fixture
+def mock_repo():
+    """Mock repo for testing."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_get_repo():
+    """Mock get_repo function for testing."""
+    with patch("git_to_prompt.cli.get_repo") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_get_commits():
+    """Mock get_commits function for testing."""
+    with patch("git_to_prompt.cli.get_commits") as mock:
+        # Create a generator that yields nothing
+        mock.return_value = (x for x in [])
+        yield mock
+
+
+@pytest.fixture
+def mock_write_commits():
+    """Mock write_commits_as_cxml function for testing."""
+    with patch("git_to_prompt.cli.write_commits_as_cxml") as mock:
+        yield mock
+
+
+def test_log_with_paths(mock_get_repo, mock_get_commits, mock_write_commits):
+    """Test log function with paths parameter."""
+    # Setup
+    repo_mock = MagicMock()
+    mock_get_repo.return_value = repo_mock
+    
+    # Call the function - simulate passing paths positionally
+    log(None, [Path("test/file.py"), Path("another/file.py")], include_patch=False)
+    
+    # Check if get_commits was called with the correct path parameters
+    mock_get_commits.assert_called_once()
+    args, _ = mock_get_commits.call_args
+    assert args[0] == repo_mock  # repo
+    assert args[1] is None  # revision_range
+    assert args[4] == ["test/file.py", "another/file.py"]  # paths
+
+
+def test_log_with_dash_dash_revision_range(mock_get_repo, mock_get_commits, mock_write_commits):
+    """Test log function with -- as revision range."""
+    # Setup
+    repo_mock = MagicMock()
+    mock_get_repo.return_value = repo_mock
+    
+    # Call the function - simulate passing -- and paths
+    log("--", [Path("test/file.py")], include_patch=False)
+    
+    # Check if get_commits was called with revision_range=None (-- is converted to None)
+    mock_get_commits.assert_called_once()
+    args, _ = mock_get_commits.call_args
+    assert args[0] == repo_mock  # repo
+    assert args[1] is None  # revision_range
+    assert args[4] == ["test/file.py"]  # paths
+
+
+def test_log_with_regular_revision_range_and_paths(mock_get_repo, mock_get_commits, mock_write_commits):
+    """Test log function with regular revision range and paths."""
+    # Setup
+    repo_mock = MagicMock()
+    mock_get_repo.return_value = repo_mock
+    
+    # Call the function
+    log("HEAD~5..HEAD", [Path("test/file.py")], include_patch=False)
+    
+    # Check if get_commits was called with the correct arguments
+    mock_get_commits.assert_called_once()
+    args, _ = mock_get_commits.call_args
+    assert args[0] == repo_mock  # repo
+    assert args[1] == "HEAD~5..HEAD"  # revision_range
+    assert args[4] == ["test/file.py"]  # paths

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,10 +89,4 @@ def test_log_with_regular_revision_range_and_paths(mock_get_repo, mock_get_commi
     assert args[4] == ["test/file.py"]  # paths
 
 
-# Let's focus our tests on the actual functionality we've implemented.
-# Since we've already tested the --delimiter functionality with our CLI commands,
-# and we have comprehensive direct function tests for the path handling,
-# we'll skip additional CLI parsing tests that can be hard to simulate.
-# 
-# The most important aspects (the function handling of paths and -- delimiter)
-# are covered by the existing tests.
+# The core functionality is tested through direct function tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
 import pytest
-from unittest.mock import patch, MagicMock
+import sys
+from unittest.mock import patch, MagicMock, call
 from pathlib import Path
+import tempfile
+from io import StringIO
 
-from git_to_prompt.cli import log
+from git_to_prompt.cli import log, app
 from git_to_prompt.log import get_commits
 
 
@@ -84,3 +87,12 @@ def test_log_with_regular_revision_range_and_paths(mock_get_repo, mock_get_commi
     assert args[0] == repo_mock  # repo
     assert args[1] == "HEAD~5..HEAD"  # revision_range
     assert args[4] == ["test/file.py"]  # paths
+
+
+# Let's focus our tests on the actual functionality we've implemented.
+# Since we've already tested the --delimiter functionality with our CLI commands,
+# and we have comprehensive direct function tests for the path handling,
+# we'll skip additional CLI parsing tests that can be hard to simulate.
+# 
+# The most important aspects (the function handling of paths and -- delimiter)
+# are covered by the existing tests.

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -140,35 +140,50 @@ def test_get_commits(temp_git_repo: Path):
 def test_get_commits_with_path_filter(temp_git_repo: Path):
     """Test retrieving commits filtered by a specific path."""
     repo = get_repo(temp_git_repo)
-    
+
     # Create a new file in a different directory
     other_dir = temp_git_repo / "other"
     other_dir.mkdir()
     other_file = other_dir / "other.txt"
     other_file.write_text("Other content")
-    
+
     # Add and commit the new file
     repo.git.add("other/other.txt")
     repo.git.commit("-m", "Add other file")
-    
+
     # Get commits filtered by test.txt path
-    test_file_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths="test.txt"))
-    
+    test_file_commits = list(
+        get_commits(repo, None, include_diffs=False, max_count=None, paths="test.txt")
+    )
+
     # Should have only commits that modified test.txt (initial + update)
     assert len(test_file_commits) == 2
-    assert all("test file" in commit.subject.lower() or "initial" in commit.subject.lower() 
-              for commit in test_file_commits)
-    
+    assert all(
+        "test file" in commit.subject.lower() or "initial" in commit.subject.lower()
+        for commit in test_file_commits
+    )
+
     # Get commits filtered by other.txt path
-    other_file_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths="other/other.txt"))
-    
+    other_file_commits = list(
+        get_commits(
+            repo, None, include_diffs=False, max_count=None, paths="other/other.txt"
+        )
+    )
+
     # Should have only the commit that added other.txt
     assert len(other_file_commits) == 1
     assert other_file_commits[0].subject == "Add other file"
-    
+
     # Test with Path objects (as the CLI now uses)
-    path_obj_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, 
-                                       paths=[Path("other/other.txt")]))
+    path_obj_commits = list(
+        get_commits(
+            repo,
+            None,
+            include_diffs=False,
+            max_count=None,
+            paths=[Path("other/other.txt")],
+        )
+    )
     assert len(path_obj_commits) == 1
     assert path_obj_commits[0].subject == "Add other file"
 
@@ -176,48 +191,63 @@ def test_get_commits_with_path_filter(temp_git_repo: Path):
 def test_get_commits_with_multiple_paths(temp_git_repo: Path):
     """Test retrieving commits filtered by multiple paths."""
     repo = get_repo(temp_git_repo)
-    
+
     # Create files in different directories
     dir1 = temp_git_repo / "dir1"
     dir1.mkdir()
     file1 = dir1 / "file1.txt"
     file1.write_text("File 1 content")
-    
+
     dir2 = temp_git_repo / "dir2"
     dir2.mkdir()
     file2 = dir2 / "file2.txt"
     file2.write_text("File 2 content")
-    
+
     # Add and commit both files together
     repo.git.add(all=True)
     repo.git.commit("-m", "Add multiple files")
-    
+
     # Update file1.txt
     file1.write_text("Updated File 1 content")
     repo.git.add("dir1/file1.txt")
     repo.git.commit("-m", "Update file1")
-    
+
     # Update file2.txt
     file2.write_text("Updated File 2 content")
     repo.git.add("dir2/file2.txt")
     repo.git.commit("-m", "Update file2")
-    
+
     # Get commits filtered by both paths
-    multi_path_commits = list(get_commits(
-        repo, None, include_diffs=False, max_count=None, 
-        paths=["dir1/file1.txt", "dir2/file2.txt"]
-    ))
-    
+    multi_path_commits = list(
+        get_commits(
+            repo,
+            None,
+            include_diffs=False,
+            max_count=None,
+            paths=["dir1/file1.txt", "dir2/file2.txt"],
+        )
+    )
+
     # Should include commits that modified either file1 or file2
-    assert len(multi_path_commits) == 3  # Initial multi-file commit + update file1 + update file2
-    assert any("multiple files" in commit.subject.lower() for commit in multi_path_commits)
-    assert any("update file1" in commit.subject.lower() for commit in multi_path_commits)
-    assert any("update file2" in commit.subject.lower() for commit in multi_path_commits)
-    
+    assert (
+        len(multi_path_commits) == 3
+    )  # Initial multi-file commit + update file1 + update file2
+    assert any(
+        "multiple files" in commit.subject.lower() for commit in multi_path_commits
+    )
+    assert any(
+        "update file1" in commit.subject.lower() for commit in multi_path_commits
+    )
+    assert any(
+        "update file2" in commit.subject.lower() for commit in multi_path_commits
+    )
+
     # Get commits for just file1
-    file1_commits = list(get_commits(
-        repo, None, include_diffs=False, max_count=None, paths="dir1/file1.txt"
-    ))
+    file1_commits = list(
+        get_commits(
+            repo, None, include_diffs=False, max_count=None, paths="dir1/file1.txt"
+        )
+    )
     assert len(file1_commits) == 2  # Initial multi-file commit + update file1
     assert not any("update file2" in commit.subject.lower() for commit in file1_commits)
 
@@ -225,38 +255,40 @@ def test_get_commits_with_multiple_paths(temp_git_repo: Path):
 def test_get_commits_with_revision_range_and_path(temp_git_repo: Path):
     """Test retrieving commits with both revision range and path filters."""
     repo = get_repo(temp_git_repo)
-    
+
     # Create a series of commits with different files
     # First commit is already there from the fixture with test.txt
-    
+
     # Add file1.txt
     file1 = temp_git_repo / "file1.txt"
     file1.write_text("File 1 content")
     repo.git.add("file1.txt")
     file1_commit = repo.git.commit("-m", "Add file1")
-    
+
     # Add file2.txt
     file2 = temp_git_repo / "file2.txt"
     file2.write_text("File 2 content")
     repo.git.add("file2.txt")
     file2_commit = repo.git.commit("-m", "Add file2")
-    
+
     # Update file1.txt
     file1.write_text("Updated File 1 content")
     repo.git.add("file1.txt")
     update_file1_commit = repo.git.commit("-m", "Update file1")
-    
+
     # Update file2.txt
     file2.write_text("Updated File 2 content")
     repo.git.add("file2.txt")
     update_file2_commit = repo.git.commit("-m", "Update file2")
-    
+
     # Get HEAD~3..HEAD commits (last 3 commits) for file1.txt
     # This should include "Add file1" and "Update file1" but not "Add file2" or "Update file2"
-    revision_path_commits = list(get_commits(
-        repo, "HEAD~4..HEAD", include_diffs=False, max_count=None, paths="file1.txt"
-    ))
-    
+    revision_path_commits = list(
+        get_commits(
+            repo, "HEAD~4..HEAD", include_diffs=False, max_count=None, paths="file1.txt"
+        )
+    )
+
     # Should have only commits related to file1.txt in the revision range
     assert len(revision_path_commits) == 2
     commit_subjects = [commit.subject for commit in revision_path_commits]
@@ -264,13 +296,18 @@ def test_get_commits_with_revision_range_and_path(temp_git_repo: Path):
     assert "Update file1" in commit_subjects
     assert "Add file2" not in commit_subjects
     assert "Update file2" not in commit_subjects
-    
+
     # Test with Path objects and multiple paths
-    path_obj_commits = list(get_commits(
-        repo, "HEAD~4..HEAD", include_diffs=False, max_count=None, 
-        paths=[Path("file1.txt"), Path("file2.txt")]
-    ))
-    
+    path_obj_commits = list(
+        get_commits(
+            repo,
+            "HEAD~4..HEAD",
+            include_diffs=False,
+            max_count=None,
+            paths=[Path("file1.txt"), Path("file2.txt")],
+        )
+    )
+
     # Should have all commits related to either file in the revision range
     assert len(path_obj_commits) == 4
     path_obj_subjects = [commit.subject for commit in path_obj_commits]
@@ -283,39 +320,45 @@ def test_get_commits_with_revision_range_and_path(temp_git_repo: Path):
 def test_get_commits_with_none_paths(temp_git_repo: Path):
     """Test that passing None for paths doesn't filter anything (backward compatibility)."""
     repo = get_repo(temp_git_repo)
-    
+
     # Create two new files
     file1 = temp_git_repo / "file1.txt"
     file1.write_text("File 1 content")
-    
+
     file2 = temp_git_repo / "file2.txt"
     file2.write_text("File 2 content")
-    
+
     # Add and commit both files
     repo.git.add(all=True)
     repo.git.commit("-m", "Add new files")
-    
+
     # Get commits with paths=None
-    all_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths=None))
-    
+    all_commits = list(
+        get_commits(repo, None, include_diffs=False, max_count=None, paths=None)
+    )
+
     # Get commits with no paths parameter
     default_commits = list(get_commits(repo, None, include_diffs=False, max_count=None))
-    
+
     # Both should return the same number of commits (all commits)
     assert len(all_commits) == len(default_commits)
-    
+
     # The commit for the new files should be included
     assert any("Add new files" in commit.subject for commit in all_commits)
-    
+
     # Compare with filtered commits to verify difference
-    file1_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths="file1.txt"))
-    assert len(file1_commits) < len(all_commits)  # Should have fewer commits when filtered
+    file1_commits = list(
+        get_commits(repo, None, include_diffs=False, max_count=None, paths="file1.txt")
+    )
+    assert len(file1_commits) < len(
+        all_commits
+    )  # Should have fewer commits when filtered
 
 
 def test_get_commits_with_empty_paths_list(temp_git_repo: Path):
     """Test that passing an empty list for paths doesn't filter anything."""
     repo = get_repo(temp_git_repo)
-    
+
     # Create two new files and commit them
     file1 = temp_git_repo / "file1.txt"
     file1.write_text("File 1 content")
@@ -323,16 +366,18 @@ def test_get_commits_with_empty_paths_list(temp_git_repo: Path):
     file2.write_text("File 2 content")
     repo.git.add(all=True)
     repo.git.commit("-m", "Add new files")
-    
+
     # Get commits with empty paths list
-    empty_list_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths=[]))
-    
+    empty_list_commits = list(
+        get_commits(repo, None, include_diffs=False, max_count=None, paths=[])
+    )
+
     # Get commits with no paths parameter
     default_commits = list(get_commits(repo, None, include_diffs=False, max_count=None))
-    
+
     # Both should return the same number of commits (all commits)
     assert len(empty_list_commits) == len(default_commits)
-    
+
     # The commit for the new files should be included
     assert any("Add new files" in commit.subject for commit in empty_list_commits)
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -135,3 +135,183 @@ def test_get_commits(temp_git_repo: Path):
     # Test with max_count
     limited_commits = list(get_commits(repo, None, include_diffs=False, max_count=1))
     assert len(limited_commits) == 1
+
+
+def test_get_commits_with_path_filter(temp_git_repo: Path):
+    """Test retrieving commits filtered by a specific path."""
+    repo = get_repo(temp_git_repo)
+    
+    # Create a new file in a different directory
+    other_dir = temp_git_repo / "other"
+    other_dir.mkdir()
+    other_file = other_dir / "other.txt"
+    other_file.write_text("Other content")
+    
+    # Add and commit the new file
+    repo.git.add("other/other.txt")
+    repo.git.commit("-m", "Add other file")
+    
+    # Get commits filtered by test.txt path
+    test_file_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths="test.txt"))
+    
+    # Should have only commits that modified test.txt (initial + update)
+    assert len(test_file_commits) == 2
+    assert all("test file" in commit.subject.lower() or "initial" in commit.subject.lower() 
+              for commit in test_file_commits)
+    
+    # Get commits filtered by other.txt path
+    other_file_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths="other/other.txt"))
+    
+    # Should have only the commit that added other.txt
+    assert len(other_file_commits) == 1
+    assert other_file_commits[0].subject == "Add other file"
+
+
+def test_get_commits_with_multiple_paths(temp_git_repo: Path):
+    """Test retrieving commits filtered by multiple paths."""
+    repo = get_repo(temp_git_repo)
+    
+    # Create files in different directories
+    dir1 = temp_git_repo / "dir1"
+    dir1.mkdir()
+    file1 = dir1 / "file1.txt"
+    file1.write_text("File 1 content")
+    
+    dir2 = temp_git_repo / "dir2"
+    dir2.mkdir()
+    file2 = dir2 / "file2.txt"
+    file2.write_text("File 2 content")
+    
+    # Add and commit both files together
+    repo.git.add(all=True)
+    repo.git.commit("-m", "Add multiple files")
+    
+    # Update file1.txt
+    file1.write_text("Updated File 1 content")
+    repo.git.add("dir1/file1.txt")
+    repo.git.commit("-m", "Update file1")
+    
+    # Update file2.txt
+    file2.write_text("Updated File 2 content")
+    repo.git.add("dir2/file2.txt")
+    repo.git.commit("-m", "Update file2")
+    
+    # Get commits filtered by both paths
+    multi_path_commits = list(get_commits(
+        repo, None, include_diffs=False, max_count=None, 
+        paths=["dir1/file1.txt", "dir2/file2.txt"]
+    ))
+    
+    # Should include commits that modified either file1 or file2
+    assert len(multi_path_commits) == 3  # Initial multi-file commit + update file1 + update file2
+    assert any("multiple files" in commit.subject.lower() for commit in multi_path_commits)
+    assert any("update file1" in commit.subject.lower() for commit in multi_path_commits)
+    assert any("update file2" in commit.subject.lower() for commit in multi_path_commits)
+    
+    # Get commits for just file1
+    file1_commits = list(get_commits(
+        repo, None, include_diffs=False, max_count=None, paths="dir1/file1.txt"
+    ))
+    assert len(file1_commits) == 2  # Initial multi-file commit + update file1
+    assert not any("update file2" in commit.subject.lower() for commit in file1_commits)
+
+
+def test_get_commits_with_revision_range_and_path(temp_git_repo: Path):
+    """Test retrieving commits with both revision range and path filters."""
+    repo = get_repo(temp_git_repo)
+    
+    # Create a series of commits with different files
+    # First commit is already there from the fixture with test.txt
+    
+    # Add file1.txt
+    file1 = temp_git_repo / "file1.txt"
+    file1.write_text("File 1 content")
+    repo.git.add("file1.txt")
+    file1_commit = repo.git.commit("-m", "Add file1")
+    
+    # Add file2.txt
+    file2 = temp_git_repo / "file2.txt"
+    file2.write_text("File 2 content")
+    repo.git.add("file2.txt")
+    file2_commit = repo.git.commit("-m", "Add file2")
+    
+    # Update file1.txt
+    file1.write_text("Updated File 1 content")
+    repo.git.add("file1.txt")
+    update_file1_commit = repo.git.commit("-m", "Update file1")
+    
+    # Update file2.txt
+    file2.write_text("Updated File 2 content")
+    repo.git.add("file2.txt")
+    update_file2_commit = repo.git.commit("-m", "Update file2")
+    
+    # Get HEAD~3..HEAD commits (last 3 commits) for file1.txt
+    # This should include "Add file1" and "Update file1" but not "Add file2" or "Update file2"
+    revision_path_commits = list(get_commits(
+        repo, "HEAD~4..HEAD", include_diffs=False, max_count=None, paths="file1.txt"
+    ))
+    
+    # Should have only commits related to file1.txt in the revision range
+    assert len(revision_path_commits) == 2
+    commit_subjects = [commit.subject for commit in revision_path_commits]
+    assert "Add file1" in commit_subjects
+    assert "Update file1" in commit_subjects
+    assert "Add file2" not in commit_subjects
+    assert "Update file2" not in commit_subjects
+
+
+def test_get_commits_with_none_paths(temp_git_repo: Path):
+    """Test that passing None for paths doesn't filter anything (backward compatibility)."""
+    repo = get_repo(temp_git_repo)
+    
+    # Create two new files
+    file1 = temp_git_repo / "file1.txt"
+    file1.write_text("File 1 content")
+    
+    file2 = temp_git_repo / "file2.txt"
+    file2.write_text("File 2 content")
+    
+    # Add and commit both files
+    repo.git.add(all=True)
+    repo.git.commit("-m", "Add new files")
+    
+    # Get commits with paths=None
+    all_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths=None))
+    
+    # Get commits with no paths parameter
+    default_commits = list(get_commits(repo, None, include_diffs=False, max_count=None))
+    
+    # Both should return the same number of commits (all commits)
+    assert len(all_commits) == len(default_commits)
+    
+    # The commit for the new files should be included
+    assert any("Add new files" in commit.subject for commit in all_commits)
+    
+    # Compare with filtered commits to verify difference
+    file1_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths="file1.txt"))
+    assert len(file1_commits) < len(all_commits)  # Should have fewer commits when filtered
+
+
+def test_get_commits_with_empty_paths_list(temp_git_repo: Path):
+    """Test that passing an empty list for paths doesn't filter anything."""
+    repo = get_repo(temp_git_repo)
+    
+    # Create two new files and commit them
+    file1 = temp_git_repo / "file1.txt"
+    file1.write_text("File 1 content")
+    file2 = temp_git_repo / "file2.txt"
+    file2.write_text("File 2 content")
+    repo.git.add(all=True)
+    repo.git.commit("-m", "Add new files")
+    
+    # Get commits with empty paths list
+    empty_list_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, paths=[]))
+    
+    # Get commits with no paths parameter
+    default_commits = list(get_commits(repo, None, include_diffs=False, max_count=None))
+    
+    # Both should return the same number of commits (all commits)
+    assert len(empty_list_commits) == len(default_commits)
+    
+    # The commit for the new files should be included
+    assert any("Add new files" in commit.subject for commit in empty_list_commits)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -165,6 +165,12 @@ def test_get_commits_with_path_filter(temp_git_repo: Path):
     # Should have only the commit that added other.txt
     assert len(other_file_commits) == 1
     assert other_file_commits[0].subject == "Add other file"
+    
+    # Test with Path objects (as the CLI now uses)
+    path_obj_commits = list(get_commits(repo, None, include_diffs=False, max_count=None, 
+                                       paths=[Path("other/other.txt")]))
+    assert len(path_obj_commits) == 1
+    assert path_obj_commits[0].subject == "Add other file"
 
 
 def test_get_commits_with_multiple_paths(temp_git_repo: Path):
@@ -258,6 +264,20 @@ def test_get_commits_with_revision_range_and_path(temp_git_repo: Path):
     assert "Update file1" in commit_subjects
     assert "Add file2" not in commit_subjects
     assert "Update file2" not in commit_subjects
+    
+    # Test with Path objects and multiple paths
+    path_obj_commits = list(get_commits(
+        repo, "HEAD~4..HEAD", include_diffs=False, max_count=None, 
+        paths=[Path("file1.txt"), Path("file2.txt")]
+    ))
+    
+    # Should have all commits related to either file in the revision range
+    assert len(path_obj_commits) == 4
+    path_obj_subjects = [commit.subject for commit in path_obj_commits]
+    assert "Add file1" in path_obj_subjects
+    assert "Update file1" in path_obj_subjects
+    assert "Add file2" in path_obj_subjects
+    assert "Update file2" in path_obj_subjects
 
 
 def test_get_commits_with_none_paths(temp_git_repo: Path):
@@ -315,3 +335,7 @@ def test_get_commits_with_empty_paths_list(temp_git_repo: Path):
     
     # The commit for the new files should be included
     assert any("Add new files" in commit.subject for commit in empty_list_commits)
+
+
+# The -- delimiter is handled at the CLI level, not directly in get_commits
+# so we're removing this test as it doesn't make sense at this level


### PR DESCRIPTION
Similar to `git log [<options>] [<revision-range>] [[--] <path>...]` but the ` [[--] <path>...]` part was not working well with Cyclopts.